### PR TITLE
Keep key case intact

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -18,7 +18,7 @@ function parse (str) {
         .split(/:([^]+)/)
         .filter(str => str.trim() !== '')
 
-      var key = data[0].toLowerCase().replace(':', '')
+      var key = data[0].replace(':', '')
 
       if (data.length >= 2) {
         var firstBreak = data[1].split('\n', 2)[1]
@@ -26,7 +26,7 @@ function parse (str) {
 
         if (isYaml) {
           try {
-            result = xtend(result, utils.keysToLowerCase(yaml.safeLoad(field)))
+            result = xtend(result, yaml.safeLoad(field))
           } catch (err) {
             result[key] = utils.setBool(data[1].trim())
           }

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -11,11 +11,14 @@ function stringify (obj) {
     .reduce(function (result, key) {
       var value = typeof obj[key] === 'undefined' ? '' : obj[key]
 
+      var stringified
       if (typeof value === 'object') {
-        result.push(yaml.safeDump({ [key]: value }))
+        stringified = yaml.safeDump({ [key]: value })
       } else {
-        result.push(key + ': ' + value)
+        stringified = key + ': ' + value
       }
+
+      result.push(stringified.trim())
 
       return result
     }, [ ])

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -10,7 +10,7 @@ function stringify (obj) {
   return objectKeys(obj)
     .reduce(function (result, key) {
       var value = typeof obj[key] === 'undefined' ? '' : obj[key]
-      
+
       if (typeof value === 'object') {
         result.push(yaml.safeDump({ [key]: value }))
       } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,32 +1,5 @@
-var objectKeys = require('object-keys')
-
 module.exports = {
-  keysToLowerCase: keysToLowerCase,
   setBool: setBool
-}
-
-function keysToLowerCase (obj) {
-  if (
-    !typeof (obj) === 'object' ||
-    typeof (obj) === 'string' ||
-    typeof (obj) === 'number' ||
-    typeof (obj) === 'boolean'
-  ) {
-    return obj
-  }
-
-  var keys = objectKeys(obj)
-  var n = keys.length
-  var lowKey
-
-  while (n--) {
-    var key = keys[n]
-    if (key === (lowKey = key.toLowerCase())) continue
-    obj[lowKey] = keysToLowerCase(obj[key])
-    delete obj[key]
-  }
-
-  return (obj)
 }
 
 function setBool (str) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hyper-readable plain text format",
   "main": "index.js",
   "scripts": {
-    "test": "standard --fix && node test.js | colortape"
+    "test": "standard --fix; ava test.js"
   },
   "repository": {
     "type": "git",
@@ -28,8 +28,7 @@
     "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "colortape": "^0.1.2",
-    "standard": "^10.0.3",
-    "tape": "^4.8.0"
+    "ava": "^0.25.0",
+    "standard": "^10.0.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -6,16 +6,18 @@ var exampleString = `title: Cyber Mysticism
 tags:
   - technopastoral
   - dark-ux
-
+----
+isMobileFriendly: true
 ----
 design:
   desktop:
     background: red
     navigation: false
+    styleUrl: desktop.css
   mobile:
     background: blue
     navigation: true
-
+    styleUrl: mobile.css
 ----
 text: We won the **battle** and lost the *war*.
 
@@ -29,14 +31,17 @@ It broke free from the commodity form.`
 var exampleObject = {
   title: 'Cyber Mysticism',
   tags: ['technopastoral', 'dark-ux'],
+  isMobileFriendly: true,
   design: {
     desktop: {
       background: 'red',
-      navigation: false
+      navigation: false,
+      styleUrl: 'desktop.css'
     },
     mobile: {
       background: 'blue',
-      navigation: true
+      navigation: true,
+      styleUrl: 'mobile.css'
     }
   },
   text: `We won the **battle** and lost the *war*.

--- a/test.js
+++ b/test.js
@@ -1,12 +1,12 @@
-var test = require('tape')
+var test = require('ava')
 var smarkt = require('.')
 
-var exampleString = `
-title: Cyber Mysticism
+var exampleString = `title: Cyber Mysticism
 ----
 tags:
   - technopastoral
   - dark-ux
+
 ----
 design:
   desktop:
@@ -15,11 +15,16 @@ design:
   mobile:
     background: blue
     navigation: true
-----
-text:
 
-We won the **battle** and lost the *war*. What Debord called détournement became not just an avant-garde but a popular cultural practice. As I wrote in [A Hacker Manifesto](https://en.wikipedia.org/wiki/A_Hacker_Manifesto): Information wants to be free but is everywhere in chains. It broke free from the commodity form.
-`
+----
+text: We won the **battle** and lost the *war*.
+
+What Debord called détournement became not just an avant-garde but a popular cultural practice.
+
+
+As I wrote in [A Hacker Manifesto](https://en.wikipedia.org/wiki/A_Hacker_Manifesto): Information wants to be free but is everywhere in chains.
+
+It broke free from the commodity form.`
 
 var exampleObject = {
   title: 'Cyber Mysticism',
@@ -34,15 +39,20 @@ var exampleObject = {
       navigation: true
     }
   },
-  text: 'We won the **battle** and lost the *war*. What Debord called détournement became not just an avant-garde but a popular cultural practice. As I wrote in [A Hacker Manifesto](https://en.wikipedia.org/wiki/A_Hacker_Manifesto): Information wants to be free but is everywhere in chains. It broke free from the commodity form.'
+  text: `We won the **battle** and lost the *war*.
+
+What Debord called détournement became not just an avant-garde but a popular cultural practice.
+
+
+As I wrote in [A Hacker Manifesto](https://en.wikipedia.org/wiki/A_Hacker_Manifesto): Information wants to be free but is everywhere in chains.
+
+It broke free from the commodity form.`
 }
 
-test('string', function (t) {
-  t.ok(typeof smarkt.stringify(exampleObject) === 'string')
-  t.end()
+test('stringify', function (t) {
+  t.deepEqual(smarkt.stringify(exampleObject), exampleString)
 })
 
-test('string', function (t) {
-  t.ok(typeof smarkt.parse(exampleString) === 'object')
-  t.end()
+test('parse', function (t) {
+  t.deepEqual(smarkt.parse(exampleString), exampleObject)
 })


### PR DESCRIPTION
Heya, as we discussed I think we should not mess with the case of the keys in the file. It makes sense for Kirby, but in JS camelCase fields are the norm, and silently changing the keys is unexpected behavior which has to be worked around if you don't want it. (see eg. [my workaround](https://github.com/lachenmayer/contentbot/commit/2531c06cc86b09234cd6ba051814c0aff17b64b2))

Also, the keys inside YAML objects weren't being lowercased at all, which is doubly confusing :) You can verify that if you check out https://github.com/jondashkyle/smarkt/commit/bc67c765f698415c88ddcd6e4403d2b313038a43 and run `npm t`.

I've completely removed the `utils.keysToLowerCase` function.

I have also slightly changed the stringify behavior: trailing whitespace is now trimmed from each value.
I changed this because YAML objects were stringified with a trailing newline - you can also verify this by checking out the test commit.
I think it makes sense to trim all values because we always trim the value when parsing anyway.

I've also changed the test framework to ava again, just for convenience.