### PR TITLE
Stringifying 'empties'

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -21,17 +21,19 @@ function parse (str) {
       var key = data[0].replace(':', '')
 
       if (data.length >= 2) {
-        var firstBreak = data[1].split('\n', 2)[1]
+        var value = data[1]
+
+        var firstBreak = value.split('\n', 2)[1]
         var isYaml = typeof firstBreak === 'string' ? firstBreak.substring(0, 2) === '  ' : false
 
         if (isYaml) {
           try {
             result = xtend(result, yaml.safeLoad(field))
           } catch (err) {
-            result[key] = utils.setBool(data[1].trim())
+            result[key] = utils.parseSpecial(value.trim())
           }
         } else {
-          result[key] = utils.setBool(data[1].trim())
+          result[key] = utils.parseSpecial(value.trim())
         }
       } else {
         result[key] = ''

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -12,7 +12,9 @@ function stringify (obj) {
       var value = typeof obj[key] === 'undefined' ? '' : obj[key]
 
       var stringified
-      if (typeof value === 'object') {
+      if (value == null) {
+        stringified = key + ':'
+      } else if (typeof value === 'object') {
         stringified = yaml.safeDump({ [key]: value })
       } else {
         stringified = key + ': ' + value

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,11 @@
 module.exports = {
-  setBool: setBool
+  parseSpecial: parseSpecial
 }
 
-function setBool (str) {
+function parseSpecial (str) {
   if (str === 'true') return true
   if (str === 'false') return false
+  if (str === '[]') return []
+  if (str === '{}') return {}
   return str
 }

--- a/test.js
+++ b/test.js
@@ -61,3 +61,20 @@ test('stringify', function (t) {
 test('parse', function (t) {
   t.deepEqual(smarkt.parse(exampleString), exampleObject)
 })
+
+const emptiesInput = { null: null, undefined: undefined, emptyArray: [], emptyString: '', emptyObject: {} }
+const emptiesStringified = `null:
+----
+undefined:
+----
+emptyArray: []
+----
+emptyString:
+----
+emptyObject: {}`
+const emptiesParsed = { null: '', undefined: '', emptyArray: [], emptyString: '', emptyObject: {} }
+
+test('empties', function (t) {
+  t.deepEqual(smarkt.stringify(emptiesInput), emptiesStringified)
+  t.deepEqual(smarkt.parse(emptiesStringified), emptiesParsed)
+})


### PR DESCRIPTION
I stumbled on a problem in my project where I was writing `null`s, and they were parsed as the string`"null"`.

We could fix this by changing the `setBool` function to also parse `"null"` as `null`. (We'd want to rename it to `parsePrimitive` or something like that). I'm not a big fan of this - I can see how `true` and `false` are useful values, but I can't think of any case where I would want to use `null` as a possible value.

Instead, I added a special case for `null`, which stringifies a `null` value as nothing, ie. `stringify({ foo: null }) == 'foo:'`. This value then gets parsed as the empty string (ie. `parse('foo:') == { foo: '' }`), which is not that much of a problem in my opinion: I expect all fields to be strings, unless I explicitly make them booleans/lists/dictionaries.

I added a test for all 'empties', ie, `null`, `undefined`, `""`, `[]` and `{}`, which threw up another issue: I would expect empty lists & dictionaries to go through stringifying & parsing intact, ie. `parse(stringify({ emptyArray: [], emptyObject: {} })) == { emptyArray: [], emptyObject: {} }`. Currently that's not the case. (The test is still failing, you can check it out)

For example, `stringify({ foo: [] }) == 'foo: []'`. This then gets parsed as `{ foo: "[]" }` - notice that it's a string, not an array. The problem is that the [parse logic](https://github.com/jondashkyle/smarkt/blob/master/lib/parse.js#L25) checks that a value is YAML by checking for 2 spaces of indentation on the next line., but `js-yaml` stringifies empty lists/dicts on the same line by default.

1. One workaround to this would be to manually add cases for empty array or empty object, and stringify them with indentation (`foo:\n  []`). This would fix the specific problem without changing the parse logic, but it would get really confusing if you were hand-writing these files (which I'm taking as the main goal).

2. Another solution is to change `setBool` to also return `setBool("[]") == []` and `setBool("{}") == {}`. (We'd also want to rename it in that case)

3. Or we change the parse logic altogether - we could parse the whole field as YAML, and if any errors occur (ie. when there are unindented multiline strings), we revert to just passing it all in as a string.

While solution 2 seems pretty hacky, it's the one I'm gravitating to right now... What do you think?