### PR TITLE
use regex for splitting

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -10,7 +10,7 @@ function parse (str) {
   assert.equal(typeof str, 'string', 'smarkt: arg1 str must be type string')
 
   return str
-    .split('\n----')
+    .split(/\n-{4}\n(?=\w+:)/)
     .filter(str => str)
     .reduce(function (result, field) {
       var data = field


### PR DESCRIPTION
proposed fix for issue #3  that uses a regex for splitting that looks ahead whether it is followed by a line break and a key + colon